### PR TITLE
fix: handle list-valued API error responses

### DIFF
--- a/catalystcentersdk/exceptions.py
+++ b/catalystcentersdk/exceptions.py
@@ -127,12 +127,18 @@ class ApiError(catalystcentersdkException):
             except ValueError:
                 logger.warning("Error parsing JSON response body")
 
-        self.message = (
-            self.details.get("message")
-            or self.details.get("response", {}).get("message")
-            or self.details.get("description")
-            if self.details and isinstance(self.details, dict)
+        details = self.details if isinstance(self.details, dict) else {}
+        response_details = details.get("response")
+        response_message = (
+            response_details.get("message")
+            if isinstance(response_details, dict)
             else None
+        )
+        self.message = (
+            details.get("message")
+            or details.get("errorMessage")
+            or response_message
+            or details.get("description")
         )
         """The error message from the parsed API response."""
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,38 @@
+import json
+
+import requests
+
+from catalystcentersdk.exceptions import ApiError
+
+
+def _response(body):
+    response = requests.Response()
+    response.status_code = 400
+    response.reason = "Bad Request"
+    response.headers["Content-Type"] = "application/json"
+    response._content = json.dumps(body).encode("utf-8")
+    return response
+
+
+def test_api_error_handles_list_response_and_preserves_error_message():
+    error = ApiError(
+        _response(
+            {
+                "response": [],
+                "errorMessage": "Field siteId is not valid.",
+                "totalCount": 0,
+                "version": "1.0",
+            }
+        )
+    )
+
+    assert error.status_code == 400
+    assert error.details["response"] == []
+    assert error.message == "Field siteId is not valid."
+    assert str(error) == "[400] Bad Request - Field siteId is not valid."
+
+
+def test_api_error_reads_nested_response_message():
+    error = ApiError(_response({"response": {"message": "Nested failure."}}))
+
+    assert error.message == "Nested failure."


### PR DESCRIPTION
## Summary

Handle Catalyst Center error envelopes where `response` is a list instead of an object. This prevents `ApiError` construction from raising `AttributeError: 'list' object has no attribute 'get'`.

The error message is also extracted from the top-level `errorMessage` field used by Catalyst Center.

## Why this is needed

The MCP Catalyst Center issues handler reproduced the failure while calling the issues endpoint with a site and priority filter:

```text
GET /dna/intent/api/v1/issues?siteId=dea014d1-8a31-4f3b-9987-c56db3ee94a1&priority=P1
```

Catalyst Center returned HTTP 400 with:

```json
{"response":[],"errorMessage":"Field siteId is not valid.","totalCount":0,"version":"1.0"}
```

Because `response` is an empty list, the SDK's exception handling called `.get()` on that list and raised `AttributeError`. That masked the actual Catalyst Center validation error and caused the MCP handler to report an unhelpful unexpected error. This fix preserves the original API failure and surfaces `Field siteId is not valid.`.

## Validation

- `TEST_CATALYST_CENTER_ENCODED_AUTH=dummy python -m pytest tests/test_exceptions.py tests/test_custom_caller.py -q` — 4 passed
- `python -m compileall -q catalystcentersdk/exceptions.py tests/test_exceptions.py`
- `git diff --check`
- `ruff check catalystcentersdk/exceptions.py tests/test_exceptions.py`

The broader suite could not be used as a gate because generated schema validators fail during collection with pre-existing JSON decode errors.
